### PR TITLE
Do variable substution in nodepool.yaml

### DIFF
--- a/docker/launcher.sh
+++ b/docker/launcher.sh
@@ -1,10 +1,27 @@
 #!/bin/bash
 
-if [ -z "$KEYPAIR_NAME" ]; then
+if [ -z "NODEPOOL_CLOUD_NAME" ]; then
+    echo "Need NODEPOOL_CLOUD_NAME to be set name of cloud in clouds.yaml"
+    exit 1
+fi
+
+if [ -z "NODEPOOL_REGION_NAME" ]; then
+    echo "Need NODEPOOL_REGION_NAME to be set to cloud region"
+    exit 1
+fi
+
+if [ -z "NODEPOOL_KEYPAIR_NAME" ]; then
     echo "Need KEYPAIR_NAME to be set to launch instances"
     exit 1
 fi
 
-echo "Setting keypair to ${KEYPAIR_NAME}"
-sed -i s/%KEYPAIR_NAME%/${KEYPAIR_NAME}/g /etc/nodepool/nodepool.yaml
+echo "Setting cloud to ${NODEPOOL_CLOUD_NAME}"
+sed -i s/%NODEPOOL_CLOUD_NAME%/${NODEPOOL_CLOUD_NAME}/g /etc/nodepool/nodepool.yaml
+
+echo "Setting region to ${NODEPOOL_REGION_NAME}"
+sed -i s/%NODEPOOL_REGION_NAME%/${NODEPOOL_REGION_NAME}/g /etc/nodepool/nodepool.yaml
+
+echo "Setting keypair to ${NODEPOOL_KEYPAIR_NAME}"
+sed -i s/%NODEPOOL_KEYPAIR_NAME%/${NODEPOOL_KEYPAIR_NAME}/g /etc/nodepool/nodepool.yaml
+
 nodepool-launcher -d -l /etc/nodepool/logging.conf

--- a/docker/nodepool.yaml
+++ b/docker/nodepool.yaml
@@ -8,9 +8,9 @@ labels:
 
 providers:
   - name: rackspace
-    cloud: hughsaunders_uk
+    cloud: %NODEPOOL_CLOUD_NAME%
     driver: openstack
-    region-name: LON
+    region-name: %NODEPOOL_REGION_NAME%
 
     cloud-images:
       - name: debian-jessie-external
@@ -22,6 +22,6 @@ providers:
           - name: debian
             cloud-image: debian-jessie-external
             flavor-name: performance1-4
-            key-name: %KEYPAIR_NAME%
+            key-name: %NODEPOOL_KEYPAIR_NAME%
 
     boot-timeout: 600


### PR DESCRIPTION
Use sed style variable substitution with the docker setup to
make the nodepool.yaml config more user-independent.