### PR TITLE
Harden code on reconnects to ZK

### DIFF
--- a/src/main/java/org/wherenow/jenkins_nodepool/NodePoolClient.java
+++ b/src/main/java/org/wherenow/jenkins_nodepool/NodePoolClient.java
@@ -163,6 +163,11 @@ public class NodePoolClient {
         return data;
     }
 
+    public boolean nodeExists(String path) throws Exception {
+        // check if the ZNode at the given path exists
+        return conn.checkExists().forPath(path) != null;
+    }
+
     /**
      * Accept the node that was created to satisfy the given request.
      *

--- a/src/main/java/org/wherenow/jenkins_nodepool/NodePoolCloud.java
+++ b/src/main/java/org/wherenow/jenkins_nodepool/NodePoolCloud.java
@@ -38,10 +38,8 @@ import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.slaves.NodeProvisioner;
 import hudson.util.ListBoxModel;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -93,8 +91,9 @@ public class NodePoolCloud extends hudson.slaves.Cloud {
             final NodePoolClient client = new NodePoolClient(connectionString, credentialsId);
             final NodeRequest request = client.requestNode(nodePoolLabel, label.getName());
 
+            final String nodeDisplayName = label + "-" + UUID.randomUUID().toString();
             final NodeProvisioner.PlannedNode plannedNode = new NodeProvisioner.PlannedNode(
-                    label + request.getNodePoolID(), // display name of node
+                    nodeDisplayName, // don't use node request id, it can change
                     new NodePoolNodeFuture(client, request),
                     1 // number of executors
 

--- a/src/main/java/org/wherenow/jenkins_nodepool/NodePoolNodeFuture.java
+++ b/src/main/java/org/wherenow/jenkins_nodepool/NodePoolNodeFuture.java
@@ -25,6 +25,8 @@ package org.wherenow.jenkins_nodepool;
 
 import hudson.model.Descriptor;
 import hudson.model.Node;
+import org.apache.zookeeper.KeeperException;
+
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
@@ -68,16 +70,16 @@ public class NodePoolNodeFuture implements Future<Node> {
     @Override
     public boolean isDone() {
 
-        LOGGER.log(Level.INFO, "isDone() polling to see if node is ready");
-
         try {
-            // refresh request from ZK:
-            final Map data = client.getZNode(request.getNodePath());
-            request.updateFromMap(data);
-        } catch (Exception e) {
-            // TODO do something smarter with the failz
-            e.printStackTrace();
+            updateNodeRequestFromZK();
+
+        } catch (KeeperException e) {
+            // connectivity issue with ZK - it should auto-reconnect and we can re-create the request then
+            LOGGER.log(Level.WARNING, e.getMessage(), e);
             return false;
+        } catch (Exception e) {
+            // let other exceptions bubble through
+            throw new RuntimeException(e);
         }
 
         // node is updated now, check it's state:
@@ -95,6 +97,31 @@ public class NodePoolNodeFuture implements Future<Node> {
         }
 
         return requestState == State.fulfilled;
+    }
+
+    private void updateNodeRequestFromZK() throws Exception {
+        Map data = null;
+
+        final boolean exists = client.nodeExists(request.getNodePath());
+
+        if (exists) {
+            // refresh request from ZK:
+            data = client.getZNode(request.getNodePath());
+
+        } else {
+            // the request node is ephemeral, so we probably just re-connected to ZK.
+            LOGGER.log(Level.INFO, "Node request " + request.getNodePath() + " no longer exists.  Submitting " +
+                    "new request...");
+
+            final NodeRequest newRequest = client.requestNode(
+                    request.getNodePoolLabel(),
+                    request.getJenkinsLabel()
+            );
+            request = newRequest;
+        }
+
+        request.updateFromMap(data);
+
     }
 
     @Override

--- a/src/main/java/org/wherenow/jenkins_nodepool/NodeRequest.java
+++ b/src/main/java/org/wherenow/jenkins_nodepool/NodeRequest.java
@@ -132,4 +132,12 @@ public class NodeRequest extends HashMap {
         return nodesMap;
     }
 
+    String getNodePoolLabel() {
+        final List<String> labels = (List<String>)get("node_types");
+        return labels.get(0);
+    }
+
+    String getJenkinsLabel() {
+        return (String)get("jenkins_label");
+    }
 }


### PR DESCRIPTION
If the ZK session disconnects, the ephemeral node request will be lost.
In this scenario, automatically detect this and re-create a new request.

(This is identical to what Zuul does in this scenario.)