### PR TITLE
Remove slave computer permission check

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
@@ -435,7 +435,6 @@ public class NodePool implements Describable<NodePool> {
         final NodePoolNode node = allocatedNodes.get(0);
         final NodePoolSlave nps = new NodePoolSlave(node, getCredentialsId());
         final Jenkins jenkins = Jenkins.getInstance();
-        jenkins.checkPermission(SlaveComputer.CREATE);
         jenkins.addNode(nps);
         LOG.log(Level.INFO, "Added NodePool slave to Jenkins: {0}", nps);
     }


### PR DESCRIPTION
Remove the permission check to create a slave computer.  It is not
needed from the context of the system thread where the listener gets
invoked from and provisions nodes.

RE-1382