### PR TITLE
RE-1386 Close Curator Connections

### DIFF
--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
@@ -516,4 +516,14 @@ public class NodePool implements Describable<NodePool> {
         }
     }
 
+    /**
+     * Release resources related to this nodepool
+     */
+    void cleanup() {
+        LOG.log(Level.INFO, "Removing Nodepool Configuration {0}", connectionString);
+        if (conn != null) {
+            conn.close();
+        }
+    }
+
 }

--- a/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
+++ b/src/main/java/com/rackspace/jenkins_nodepool/NodePool.java
@@ -445,13 +445,11 @@ public class NodePool implements Describable<NodePool> {
             new FormFieldValidator(req, resp, true) {
                 @Override
                 protected void check() throws IOException, ServletException {
-                    try {
-                        CuratorFramework testConn = NodePool.createZKConnection(connectionString, zooKeeperRoot);
+                    try (CuratorFramework testConn = NodePool.createZKConnection(connectionString, zooKeeperRoot)) {
                         testConn.create()
                                 .creatingParentsIfNeeded()
                                 .withMode(CreateMode.EPHEMERAL)
                                 .forPath(MessageFormat.format("/testing/{0}", req.getSession().getId()));
-                        testConn.close();
                         ok(MessageFormat.format("Successfully connected to Zookeeper at {0}", connectionString));
                     } catch (Exception e) {
                         error(MessageFormat.format("Failed to connecto to ZooKeeper :( {0}", e.getMessage()));


### PR DESCRIPTION
Close the curator connection in two situations:

1. When testing the connection string and the test fails
1. When removing a nodepool configuration from Jenkins